### PR TITLE
[*] Fix readint bug:

### DIFF
--- a/headers/memutils.h
+++ b/headers/memutils.h
@@ -1,4 +1,4 @@
 #include <stdio.h>
 
 // Copy memory as int
-int readint(const FILE *fptr, size_t size);
+unsigned int read_unsigned_integer(const FILE *file_descriptor, size_t read_size);

--- a/headers/midifile.h
+++ b/headers/midifile.h
@@ -2,10 +2,10 @@
 #include "errutils.h"
 
 typedef struct {
-	int format;
-	int header_length;
-	int track_chunks_number;
-	int division;
+    unsigned int format;
+    unsigned int header_length;
+    unsigned int track_chunks_number;
+    unsigned int division;
 } Midifile;
 
 Midifile* midiface_open_file(const char *filename);

--- a/sources/memutils.c
+++ b/sources/memutils.c
@@ -2,14 +2,13 @@
 #include <headers/types.h>
 
 
-int readint(FILE *fptr, int size)
-{
-   byte_t bytes[size];
-   int value=0;
+unsigned int read_unsigned_integer(const FILE *file_descriptor, const size_t read_size) {
+    byte_t bytes[read_size];
+    unsigned int value = 0;
 
-   fread(bytes, size, 1, fptr);
-   for(int i=0; i < size; i++) {
-      value = value << 1 | bytes[i];
+    fread(bytes, read_size, 1, file_descriptor);
+    for (unsigned int power = 0; power < read_size; power++) {
+        value = value + (bytes[power] << (power * 8));
    }
 
    return value;

--- a/sources/midifile.c
+++ b/sources/midifile.c
@@ -18,10 +18,10 @@ Midifile *midiface_open_file(const char *filename) {
     if (!(midiface_validate_header(mthd))) {
         midifile_add_error(WRONG_MTHD);
     }
-    midifile->header_length = readint(fptr, 4);
-    midifile->format = readint(fptr, 2);
-    midifile->track_chunks_number = readint(fptr, 2);
-    midifile->division = readint(fptr, 2);
+    midifile->header_length = read_unsigned_integer(fptr, 4);
+    midifile->format = read_unsigned_integer(fptr, 2);
+    midifile->track_chunks_number = read_unsigned_integer(fptr, 2);
+    midifile->division = read_unsigned_integer(fptr, 2);
     return midifile;
 }
 

--- a/tests/sources/test_memutils.c
+++ b/tests/sources/test_memutils.c
@@ -4,33 +4,33 @@
 
 void read_int_4_bytes_test() {
     void *data = malloc(sizeof(int));
-    const unsigned int source_integer = 0b1111111111111111111111111111111; // 2147483647
+    const unsigned int source_integer = 0b11111111111111111111111111111111; // 4294967295
     memcpy(data, &source_integer, 4);
     const FILE *stream = fmemopen(data, 4, "rb");
 
-    const int read_integer = readint(stream, 4);
+    const unsigned int read_integer = read_unsigned_integer(stream, 4);
 
     CU_ASSERT_EQUAL(read_integer, source_integer);
 }
 
 void read_int_3_bytes_test() {
     void *data = malloc(sizeof(int));
-    const unsigned int source_integer = 0b11111111111111111111111; // 8388607
+    const unsigned int source_integer = 0b111111111111111111111111; // 16777215
     memcpy(data, &source_integer, 3);
     const FILE *stream = fmemopen(data, 3, "rb");
 
-    const int read_integer = readint(stream, 3);
+    const unsigned int read_integer = read_unsigned_integer(stream, 3);
 
     CU_ASSERT_EQUAL(read_integer, source_integer);
 }
 
 void read_int_2_bytes_test() {
     void *data = malloc(sizeof(int));
-    const short unsigned int source_integer = 0b111111111111111; // 32767
+    const short unsigned int source_integer = 0b1111111111111111; // 65535
     memcpy(data, &source_integer, 2);
     const FILE *stream = fmemopen(data, 2, "rb");
 
-    const int read_integer = readint(stream, 2);
+    const unsigned int read_integer = read_unsigned_integer(stream, 2);
 
     CU_ASSERT_EQUAL(read_integer, source_integer);
 }
@@ -41,7 +41,7 @@ void read_int_1_byte_test() {
     memcpy(data, &source_integer, 1);
     const FILE *stream = fmemopen(data, 1, "rb");
 
-    const int read_integer = readint(stream, 1);
+    const unsigned int read_integer = read_unsigned_integer(stream, 1);
 
     CU_ASSERT_EQUAL(read_integer, source_integer);
 }
@@ -52,7 +52,7 @@ void read_int_half_byte_test() {
     memcpy(data, &source_integer, 1);
     const FILE *stream = fmemopen(data, 1, "rb");
 
-    const int read_integer = readint(stream, 1);
+    const unsigned int read_integer = read_unsigned_integer(stream, 1);
 
     CU_ASSERT_EQUAL(read_integer, source_integer);
 }
@@ -63,7 +63,18 @@ void read_int_quarter_byte_test() {
     memcpy(data, &source_integer, 1);
     const FILE *stream = fmemopen(data, 1, "rb");
 
-    const int read_integer = readint(stream, 1);
+    const unsigned int read_integer = read_unsigned_integer(stream, 1);
+    CU_ASSERT_EQUAL(read_integer, source_integer);
+}
+
+void read_int_eleven_bit_on_test() {
+    void *data = malloc(sizeof(int));
+    const short unsigned int source_integer = 0b0000010000000000; // 1024
+    memcpy(data, &source_integer, 2);
+    const FILE *stream = fmemopen(data, 2, "rb");
+
+    const unsigned int read_integer = read_unsigned_integer(stream, 2);
+
     CU_ASSERT_EQUAL(read_integer, source_integer);
 }
 
@@ -75,6 +86,8 @@ void init_memutils_suite() {
                 read_int_3_bytes_test);
     CU_add_test(memutils_test_suite, "Test read integer of 16 bits",
                 read_int_2_bytes_test);
+    CU_add_test(memutils_test_suite, "Test read 1024 from 16 bits",
+                read_int_eleven_bit_on_test);
     CU_add_test(memutils_test_suite, "Test read integer of 8 bits",
                 read_int_1_byte_test);
     CU_add_test(memutils_test_suite, "Test read integer of 4 bits",


### PR DESCRIPTION
- Adding test case for 1024 reading
- Clarifying variable and function names
- Make all memutils test passing green
- Switching read (signed) integers to unsigned integers