### PR TITLE
[*] Enhance error system

### DIFF
--- a/headers/errutils.h
+++ b/headers/errutils.h
@@ -1,16 +1,21 @@
 #ifndef ERR_UTILS
+#define ERR_UTILS
 
-#define FATAL 0b10000000
+#define FATAL 0b1000000000000000000000000000000
 #define MIDIFILE_OK 0x01
-#define WRONG_MTHD  0x02
-#define FILE_NOT_FOUND 0x03
+#define WRONG_MTHD  (0x02 + FATAL)
+#define FILE_NOT_FOUND (0x03 + FATAL)
 
 #define MAX_ERRORS 256
 
-int midifile_get_last_error();
-void midifile_add_error(int code);
+#define ERROR_STRING_HEADER "ERROR:"
+#define FATAL_STRING_HEADER "FATAL ERROR:"
 
-extern int midifile_errors[MAX_ERRORS];
+unsigned int midifile_get_last_error();
+
+void midifile_throw_error(unsigned int code);
+
+extern unsigned int midifile_errors[MAX_ERRORS];
 extern int err_count;
 
 #endif

--- a/sources/errutils.c
+++ b/sources/errutils.c
@@ -1,24 +1,48 @@
 #include <headers/errutils.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-
-int midifile_errors[MAX_ERRORS]={MIDIFILE_OK};
+unsigned int midifile_errors[MAX_ERRORS] = {MIDIFILE_OK};
 int err_count=0;
 
 
-int midifile_get_last_error()
-{
-   int error=midifile_errors[0];
-   for(int i=0; i < err_count; i++) {
+unsigned int midifile_get_last_error() {
+    const unsigned int error = midifile_errors[0];
+    for (int i = 0; i < err_count; i++) {
       midifile_errors[i] = midifile_errors[i + 1];
-   }
-   if(err_count >= 0) {
+    }
+    if (err_count >= 0) {
       err_count = err_count - 1;
-   }
-   return error;
+    }
+    return error;
 }
 
-void midifile_add_error(int code)
-{
+char *midifile_get_last_error_string(const unsigned int code) {
+    char *error_string = malloc(512 * sizeof(char));
+    if (code == FILE_NOT_FOUND) {
+        sprintf(error_string, "%s - %s", "Can not open file", strerror(errno));
+    } else if (code == WRONG_MTHD) {
+        sprintf(error_string, "%s", "Wrong track header type (probably not a MIDI file format)");
+    } else {
+        sprintf(error_string, "Unknown error - %s", strerror(errno));
+    }
+    return error_string;
+}
+
+void midifile_add_error(const unsigned int code) {
    midifile_errors[err_count] = code;
    err_count = err_count + 1;
+}
+
+void midifile_throw_error(const unsigned int code) {
+    midifile_add_error(code);
+    const char *error_string = midifile_get_last_error_string(code);
+    const static unsigned int fatal_code = FATAL;
+    if (code & fatal_code) {
+        fprintf(stdout, "%s: %s", FATAL_STRING_HEADER, error_string);
+        exit(EXIT_FAILURE);
+    }
+    fprintf(stdout, "%s: %s", ERROR_STRING_HEADER, error_string);
 }

--- a/sources/midifile.c
+++ b/sources/midifile.c
@@ -11,12 +11,11 @@ Midifile *midiface_open_file(const char *filename) {
     byte_t mthd[4];
     Midifile *midifile = malloc(sizeof(Midifile));
     if ((fptr = fopen(filename, "r")) == NULL) {
-        midifile_add_error(FILE_NOT_FOUND);
-        return NULL;
+        midifile_throw_error(FILE_NOT_FOUND);
     }
     fread(mthd, 4, 1, fptr);
     if (!(midiface_validate_header(mthd))) {
-        midifile_add_error(WRONG_MTHD);
+        midifile_throw_error(WRONG_MTHD);
     }
     midifile->header_length = read_unsigned_integer(fptr, 4);
     midifile->format = read_unsigned_integer(fptr, 2);


### PR DESCRIPTION
- Specify fatal by binary flag
- Display error when it happens
- midifile_throw_error() instead of midifile_add_error()
- unsigned instead of signed integer when using bitwise opearator