### PR TITLE
[+] #28: stream handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 add_library(midiface SHARED sources/errutils.c
         sources/memutils.c
         sources/midifile.c
-        sources/logger.c)
+        sources/logger.c
+        sources/midistream.c)
 
 set_target_properties (midiface PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties (midiface PROPERTIES SOVERSION 1)

--- a/headers/errutils.h
+++ b/headers/errutils.h
@@ -5,6 +5,7 @@
 #define MIDIFILE_OK 0x01
 #define WRONG_MTHD  (0x02 + FATAL)
 #define FILE_NOT_FOUND (0x03 + FATAL)
+#define NOT_IMPLEMENTED (0x04 + FATAL)
 
 #define MAX_ERRORS 256
 

--- a/headers/midifile.h
+++ b/headers/midifile.h
@@ -1,15 +1,17 @@
 #include "types.h"
 #include "errutils.h"
+#include "midiheader.h"
+
+#include <stdio.h>
 
 typedef struct {
-    unsigned int format;
-    unsigned int header_length;
-    unsigned int track_chunks_number;
-    unsigned int division;
-} Midifile;
+    MIDIHeader *header;
+    FILE *file;
+} MIDIFile;
 
-Midifile* midiface_open_file(const char *filename);
+MIDIFile *midiface_open_file(const char *filename);
 
-void midiface_dump_midifile_header(const Midifile *midifile);
-void midiface_close_midifile(Midifile *midifile);
+void midiface_dump_midifile_header(const MIDIFile *midifile);
+
+void midiface_close_midifile(MIDIFile *midifile);
 bool midiface_validate_header(byte_t *bytes);

--- a/headers/midiheader.h
+++ b/headers/midiheader.h
@@ -1,0 +1,11 @@
+#ifndef MIDIFACE_MIDIHEADER_H
+#define MIDIFACE_MIDIHEADER_H
+
+typedef struct {
+    unsigned int format;
+    unsigned int length;
+    unsigned int ntracks;
+    unsigned int division;
+} MIDIHeader;
+
+#endif //MIDIFACE_MIDIHEADER_H

--- a/headers/midistream.h
+++ b/headers/midistream.h
@@ -1,0 +1,29 @@
+#ifndef MIDIFACE_MIDISTREAM_H
+#define MIDIFACE_MIDISTREAM_H
+
+#include <headers/midiheader.h>
+
+#include <stdio.h>
+
+enum Stream_Type {
+    IMMUTABLE, CONTINUOUS, LISTENING
+};
+
+typedef struct {
+    enum Stream_Type type;
+    void *source;
+} MIDIStream;
+
+MIDIStream *midiface_create_stream(enum Stream_Type);
+
+void midiface_open_stream_source(MIDIStream *, const char *);
+
+void midiface_dump_stream_header(MIDIStream *);
+
+MIDIHeader *midiface_get_stream_header(MIDIStream *);
+
+int midiface_get_stream_length(const MIDIStream *);
+
+void midiface_close_stream(MIDIStream *);
+
+#endif //MIDIFACE_MIDISTREAM_H

--- a/headers/midistream.h
+++ b/headers/midistream.h
@@ -15,15 +15,10 @@ typedef struct {
 } MIDIStream;
 
 MIDIStream *midiface_create_stream(enum Stream_Type);
-
 void midiface_open_stream_source(MIDIStream *, const char *);
-
 void midiface_dump_stream_header(MIDIStream *);
-
 MIDIHeader *midiface_get_stream_header(MIDIStream *);
-
 int midiface_get_stream_length(const MIDIStream *);
-
 void midiface_close_stream(MIDIStream *);
 
 #endif //MIDIFACE_MIDISTREAM_H

--- a/sources/midifile.c
+++ b/sources/midifile.c
@@ -1,15 +1,17 @@
 #include <headers/midifile.h>
 #include <headers/memutils.h>
 #include <headers/midispec.h>
+#include <headers/logger.h>
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-Midifile *midiface_open_file(const char *filename) {
+MIDIFile *midiface_open_file(const char *filename) {
     FILE *fptr;
     byte_t mthd[4];
-    Midifile *midifile = malloc(sizeof(Midifile));
+    MIDIFile *midifile = malloc(sizeof(MIDIFile));
+    midifile->header = malloc(sizeof(MIDIHeader));
     if ((fptr = fopen(filename, "r")) == NULL) {
         midifile_throw_error(FILE_NOT_FOUND);
     }
@@ -17,10 +19,11 @@ Midifile *midiface_open_file(const char *filename) {
     if (!(midiface_validate_header(mthd))) {
         midifile_throw_error(WRONG_MTHD);
     }
-    midifile->header_length = read_unsigned_integer(fptr, 4);
-    midifile->format = read_unsigned_integer(fptr, 2);
-    midifile->track_chunks_number = read_unsigned_integer(fptr, 2);
-    midifile->division = read_unsigned_integer(fptr, 2);
+    midifile->file = fptr;
+    midifile->header->length = read_unsigned_integer(fptr, 4);
+    midifile->header->format = read_unsigned_integer(fptr, 2);
+    midifile->header->ntracks = read_unsigned_integer(fptr, 2);
+    midifile->header->division = read_unsigned_integer(fptr, 2);
     return midifile;
 }
 
@@ -29,21 +32,12 @@ bool midiface_validate_header(byte_t *bytes) {
     return memcmp(bytes, mthd, sizeof mthd) == 0;
 }
 
-void midiface_dump_midifile_header(const Midifile *midifile) {
-    printf("format: %s (%d)\n"
-           "number of tracks: %d\n"
-           "division: %d\n",
-           FILE_FORMAT_STRING_DESCRIPTION(midifile->format),
-           midifile->format,
-           midifile->track_chunks_number,
-           midifile->division);
-}
-
-void midiface_close_midifile(Midifile *midifile) {
+void midiface_close_midifile(MIDIFile *midifile) {
     /*
     if(midifile->tracks != NULL) {
        free(midifile->tracks);
     }
     */
+    send_log(DEBUG, "freeing MIDIFile@%p", midifile);
     free(midifile);
 }

--- a/sources/midistream.c
+++ b/sources/midistream.c
@@ -1,0 +1,85 @@
+#include <headers/midifile.h>
+#include <headers/midistream.h>
+#include <headers/midispec.h>
+#include <headers/errutils.h>
+#include <headers/logger.h>
+
+#include <malloc.h>
+#include <stdio.h>
+
+#define \
+    STREAM_TYPE_AS_STRING(STREAM_TYPE) \
+    ({ \
+        (STREAM_TYPE) == IMMUTABLE ? "IMMUTABLE" : \
+        (STREAM_TYPE) == CONTINUOUS ? "CONTINUOUS" : \
+        (STREAM_TYPE) == LISTENING ? "LISTENING" : \
+        "WRONG FORMAT"; \
+    })
+
+MIDIStream *midiface_create_stream(const enum Stream_Type type) {
+    MIDIStream *stream = malloc(sizeof(MIDIStream));
+    stream->type = type;
+    send_log(DEBUG, "%s@%p stream created", STREAM_TYPE_AS_STRING(type), stream);
+    return stream;
+}
+
+// Renaming because "source" is confusing
+void midiface_open_stream_source(MIDIStream *stream, const char *source_name) {
+    if (stream->type == IMMUTABLE) {
+        stream->source = midiface_open_file(source_name);
+    } else if (stream->type == CONTINUOUS) {
+        send_log(ERROR, "Continuous stream source opening not implemented");
+        midifile_throw_error(NOT_IMPLEMENTED);
+    } else if (stream->type == LISTENING) {
+        send_log(ERROR, "Listening stream source opening not implemented");
+        midifile_throw_error(NOT_IMPLEMENTED);
+    }
+}
+
+int midiface_get_stream_length(const MIDIStream *stream) {
+    size_t source_size = -1;
+    if (stream->type == IMMUTABLE) {
+        MIDIFile *midifile = (MIDIFile *) stream->source;
+        const size_t initial_position = ftell(midifile->file);
+        fseek(midifile->file, 0, SEEK_END);
+        source_size = ftell(midifile->file);
+        fseek(midifile->file, initial_position, SEEK_SET);
+    } else if (stream->type == CONTINUOUS || stream->type == LISTENING) {
+        // CONTINUOUS and LISTENING have infinite length because it sends at any time any data
+        // A size should be calculated after it has been closed.
+        source_size = -1;
+    }
+    return source_size;
+}
+
+void midiface_close_stream(MIDIStream *stream) {
+    midiface_close_midifile(stream->source);
+    send_log(DEBUG, "freeing %s@%p stream", STREAM_TYPE_AS_STRING(stream->type), stream);
+    free(stream);
+}
+
+void midiface_dump_stream_header(MIDIStream *stream) {
+    const MIDIHeader *header = midiface_get_stream_header(stream);
+    printf("format: %s (%d)\n"
+           "number of tracks: %d\n"
+           "division: %d\n",
+           FILE_FORMAT_STRING_DESCRIPTION(header->format),
+           header->format,
+           header->ntracks,
+           header->division);
+}
+
+MIDIHeader *midiface_get_stream_header(MIDIStream *stream) {
+    MIDIHeader *header = NULL;
+    if (stream->type == IMMUTABLE) {
+        MIDIFile *source = (MIDIFile *) stream->source;
+        header = source->header;
+    } else if (stream->type == CONTINUOUS) {
+        send_log(ERROR, "Continuous stream header getting not implemented");
+        midifile_throw_error(NOT_IMPLEMENTED);
+    } else if (stream->type == LISTENING) {
+        send_log(ERROR, "Listening stream header getting not implemented");
+        midifile_throw_error(NOT_IMPLEMENTED);
+    }
+    return header;
+}

--- a/tests/sources/test_midifile.c
+++ b/tests/sources/test_midifile.c
@@ -1,11 +1,11 @@
 #include <headers/midifile.h>
 
 void midi_file_valid_header_test() {
-    const Midifile *valid_MIDIFile = midiface_open_file("tests/files/SuperMario64.mid");
-    CU_ASSERT_EQUAL(valid_MIDIFile->header_length, 6);
-    CU_ASSERT_EQUAL(valid_MIDIFile->format, 1);
-    CU_ASSERT_EQUAL(valid_MIDIFile->track_chunks_number, 3);
-    CU_ASSERT_EQUAL(valid_MIDIFile->division, 1024);
+    const MIDIFile *valid_MIDIFile = midiface_open_file("tests/files/SuperMario64.mid");
+    CU_ASSERT_EQUAL(valid_MIDIFile->header->length, 6);
+    CU_ASSERT_EQUAL(valid_MIDIFile->header->format, 1);
+    CU_ASSERT_EQUAL(valid_MIDIFile->header->ntracks, 3);
+    CU_ASSERT_EQUAL(valid_MIDIFile->header->division, 1024);
 }
 
 void init_midifile_suite() {

--- a/tests/sources/test_midistream.c
+++ b/tests/sources/test_midistream.c
@@ -1,0 +1,25 @@
+#include "headers/midistream.h"
+
+
+/**
+ * The immutable stream does not send data continuously, it is often a file read once and closed.
+ * This stream has a length because it is ending.
+ */
+void test_immutable_stream() {
+    MIDIStream *stream = midiface_create_stream(IMMUTABLE);
+    midiface_open_stream_source(stream, "tests/files/SuperMario64.mid");
+    MIDIHeader *header = midiface_get_stream_header(stream);
+    const int stream_length = midiface_get_stream_length(stream);
+    CU_ASSERT_EQUAL(48700, stream_length);
+    CU_ASSERT_EQUAL(header->length, 6);
+    CU_ASSERT_EQUAL(header->format, 1);
+    CU_ASSERT_EQUAL(header->ntracks, 3);
+    CU_ASSERT_EQUAL(header->division, 1024);
+    midiface_close_stream(stream);
+}
+
+void init_midistream_suite() {
+    CU_pSuite stream_test_suite = CU_add_suite("Test stream reading/writing", NULL, NULL);
+    CU_add_test(stream_test_suite, "Test that an immutable stream from a file on the system is correct",
+                test_immutable_stream);
+}

--- a/tests/sources/tests.c
+++ b/tests/sources/tests.c
@@ -1,11 +1,13 @@
 #include <CUnit/Basic.h>
 #include "test_midifile.c"
+#include "test_midistream.c"
 #include "test_memutils.c"
 #include "test_logger.c"
 
 void init_test_suites() {
     init_memutils_suite();
     init_midifile_suite();
+    init_midistream_suite();
     init_logger_suite();
 }
 


### PR DESCRIPTION
- Read data from a stream interface instead of a raw file
- Separating header from MIDIFile
- Preparing implementations of other type of streams
- Changing some variable names
- Adding logs
- Changing the case of structure names
- Automate IMMUTABLE stream opening and reading test