### PR TITLE
[*] #29 - error checking

### DIFF
--- a/headers/errutils.h
+++ b/headers/errutils.h
@@ -4,17 +4,20 @@
 #define FATAL 0b1000000000000000000000000000000
 #define MIDIFILE_OK 0x01
 #define WRONG_MTHD  (0x02 + FATAL)
-#define FILE_NOT_FOUND (0x03 + FATAL)
+#define FILE_OPENING (0x03 + FATAL)
 #define NOT_IMPLEMENTED (0x04 + FATAL)
+#define READ_EXCEPTION (0x05 + FATAL)
+#define NO_SOURCE (0x06 + FATAL)
+#define NO_SOURCE_HEADER 0x07
 
 #define MAX_ERRORS 256
 
 #define ERROR_STRING_HEADER "ERROR:"
 #define FATAL_STRING_HEADER "FATAL ERROR:"
 
-unsigned int midifile_get_last_error();
+unsigned int midiface_pop_last_error();
 
-void midifile_throw_error(unsigned int code);
+void midiface_throw_error(unsigned int code);
 
 extern unsigned int midifile_errors[MAX_ERRORS];
 extern int err_count;

--- a/headers/memutils.h
+++ b/headers/memutils.h
@@ -1,4 +1,8 @@
 #include <stdio.h>
 
 // Copy memory as int
-unsigned int read_unsigned_integer(const FILE *file_descriptor, size_t read_size);
+unsigned int read_unsigned_integer(FILE *file_descriptor, size_t read_size);
+
+size_t secure_fread(char *buffer, size_t size, size_t n, FILE *file_descriptor);
+
+int secure_fseek(FILE *, size_t offset, int whence);

--- a/headers/midistream.h
+++ b/headers/midistream.h
@@ -16,9 +16,12 @@ typedef struct {
 
 MIDIStream *midiface_create_stream(enum Stream_Type);
 void midiface_open_stream_source(MIDIStream *, const char *);
+
+void *midiface_get_stream_source(MIDIStream *);
 void midiface_dump_stream_header(MIDIStream *);
 MIDIHeader *midiface_get_stream_header(MIDIStream *);
-int midiface_get_stream_length(const MIDIStream *);
+
+int midiface_get_stream_length(MIDIStream *);
 void midiface_close_stream(MIDIStream *);
 
 #endif //MIDIFACE_MIDISTREAM_H

--- a/sources/memutils.c
+++ b/sources/memutils.c
@@ -1,12 +1,14 @@
+#include <headers/errutils.h>
+#include <headers/logger.h>
 #include <headers/memutils.h>
 #include <headers/types.h>
 
 
-unsigned int read_unsigned_integer(const FILE *file_descriptor, const size_t read_size) {
+unsigned int read_unsigned_integer(FILE *file_descriptor, const size_t read_size) {
     byte_t bytes[read_size];
     unsigned int value = 0;
 
-    fread(bytes, read_size, 1, file_descriptor);
+    secure_fread(bytes, sizeof(char), read_size, file_descriptor);
     // The most significant byte is the first so the most higher
     // power is at the beginning of the file cursor when
     // reading.
@@ -16,5 +18,23 @@ unsigned int read_unsigned_integer(const FILE *file_descriptor, const size_t rea
         power = power + 1;
     }
 
-   return value;
+    return value;
+}
+
+size_t secure_fread(char *buffer, const size_t size, const size_t n, FILE *file_descriptor) {
+    if (size * n != fread(buffer, size, n, file_descriptor)) {
+        if (feof(file_descriptor)) {
+            send_log(INFO, "End of stream@%p reached", file_descriptor);
+        } else {
+            midiface_throw_error(READ_EXCEPTION);
+        }
+    }
+}
+
+int secure_fseek(FILE *file_descriptor, size_t offset, int whence) {
+    const int result = fseek(file_descriptor, offset, whence);
+    if (result != 0) {
+        midiface_throw_error(READ_EXCEPTION);
+    }
+    return result;
 }

--- a/sources/midifile.c
+++ b/sources/midifile.c
@@ -12,11 +12,11 @@ MIDIFile *midiface_open_file(const char *filename) {
     MIDIFile *midifile = malloc(sizeof(MIDIFile));
     midifile->header = malloc(sizeof(MIDIHeader));
     if ((fptr = fopen(filename, "r")) == NULL) {
-        midifile_throw_error(FILE_NOT_FOUND);
+        midiface_throw_error(FILE_OPENING);
     }
-    fread(mthd, 4, 1, fptr);
+    secure_fread(mthd, 1, 4, fptr);
     if (!(midiface_validate_header(mthd))) {
-        midifile_throw_error(WRONG_MTHD);
+        midiface_throw_error(WRONG_MTHD);
     }
     midifile->file = fptr;
     midifile->header->length = read_unsigned_integer(fptr, 4);

--- a/tests/sources/test_memutils.c
+++ b/tests/sources/test_memutils.c
@@ -6,7 +6,7 @@ void read_int_4_bytes_test() {
     void *data = malloc(sizeof(int));
     const unsigned int source_integer = 0b11111111111111111111111111111111; // 4294967295
     memcpy(data, &source_integer, 4);
-    const FILE *stream = fmemopen(data, 4, "rb");
+    FILE *stream = fmemopen(data, 4, "rb");
 
     const unsigned int read_integer = read_unsigned_integer(stream, 4);
 
@@ -17,7 +17,7 @@ void read_int_3_bytes_test() {
     void *data = malloc(sizeof(int));
     const unsigned int source_integer = 0b111111111111111111111111; // 16777215
     memcpy(data, &source_integer, 3);
-    const FILE *stream = fmemopen(data, 3, "rb");
+    FILE *stream = fmemopen(data, 3, "rb");
 
     const unsigned int read_integer = read_unsigned_integer(stream, 3);
 
@@ -28,7 +28,7 @@ void read_int_2_bytes_test() {
     void *data = malloc(sizeof(int));
     const short unsigned int source_integer = 0b1111111111111111; // 65535
     memcpy(data, &source_integer, 2);
-    const FILE *stream = fmemopen(data, 2, "rb");
+    FILE *stream = fmemopen(data, 2, "rb");
 
     const unsigned int read_integer = read_unsigned_integer(stream, 2);
 
@@ -39,7 +39,7 @@ void read_int_1_byte_test() {
     void *data = malloc(sizeof(int));
     const short unsigned int source_integer = 0b000000011111111; // 127
     memcpy(data, &source_integer, 1);
-    const FILE *stream = fmemopen(data, 1, "rb");
+    FILE *stream = fmemopen(data, 1, "rb");
 
     const unsigned int read_integer = read_unsigned_integer(stream, 1);
 
@@ -50,7 +50,7 @@ void read_int_half_byte_test() {
     void *data = malloc(sizeof(int));
     const short unsigned int source_integer = 0b000000000001111; // 15
     memcpy(data, &source_integer, 1);
-    const FILE *stream = fmemopen(data, 1, "rb");
+    FILE *stream = fmemopen(data, 1, "rb");
 
     const unsigned int read_integer = read_unsigned_integer(stream, 1);
 
@@ -61,7 +61,7 @@ void read_int_quarter_byte_test() {
     void *data = malloc(sizeof(int));
     const short unsigned int source_integer = 0b0000000000000011; // 3
     memcpy(data, &source_integer, 1);
-    const FILE *stream = fmemopen(data, 1, "rb");
+    FILE *stream = fmemopen(data, 1, "rb");
 
     const unsigned int read_integer = read_unsigned_integer(stream, 1);
     CU_ASSERT_EQUAL(read_integer, source_integer);
@@ -71,7 +71,7 @@ void read_int_eleven_bit_on_test() {
     void *data = malloc(sizeof(int));
     const short unsigned int source_integer = 0b0000000000000100; // 1024
     memcpy(data, &source_integer, 2);
-    const FILE *stream = fmemopen(data, 2, "rb");
+    FILE *stream = fmemopen(data, 2, "rb");
 
     const unsigned int read_integer = read_unsigned_integer(stream, 2);
 

--- a/tests/sources/test_midistream.c
+++ b/tests/sources/test_midistream.c
@@ -18,8 +18,20 @@ void test_immutable_stream() {
     midiface_close_stream(stream);
 }
 
+void test_midistream_file_get_source() {
+    MIDIStream *stream = midiface_create_stream(IMMUTABLE);
+    midiface_open_stream_source(stream, "tests/files/SuperMario64.mid");
+    MIDIFile *midifile = midiface_get_stream_source(stream);
+    CU_ASSERT_EQUAL(midifile->header->length, 6);
+    CU_ASSERT_EQUAL(midifile->header->format, 1);
+    CU_ASSERT_EQUAL(midifile->header->ntracks, 3);
+    CU_ASSERT_EQUAL(midifile->header->division, 1024);
+}
+
 void init_midistream_suite() {
     CU_pSuite stream_test_suite = CU_add_suite("Test stream reading/writing", NULL, NULL);
     CU_add_test(stream_test_suite, "Test that an immutable stream from a file on the system is correct",
                 test_immutable_stream);
+    CU_add_test(stream_test_suite, "Test that an immutable stream from a file gets its source correctly",
+                test_midistream_file_get_source);
 }


### PR DESCRIPTION
- adding error check when opening files
- adding error check when accessing source of a stream
- adding few errors with their descriptions
- replacing fread with a secure one
- replacing fseek with a secure one
- midiface_get_stream_source is now error catching
- clean build output by removing const warnings
- errutils send to logger properly
- renaming error functions
- functions that are not exported are no longer in header files are no longer prefixed by midiface
- automate immutable stream source getting test