### PR TITLE
[*] Test memory management: Closes #40

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,13 @@
 cmake_minimum_required(VERSION 3.14)
-project (midiface VERSION 0.0.1 DESCRIPTION "Midi interface")
+project(midiface VERSION 0.0.1 DESCRIPTION "Virtual MIDI hub")
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_library(midiface SHARED sources/errutils.c
-        sources/memutils.c
-        sources/midifile.c
         sources/logger.c
+        sources/memutils.c
+        sources/midiheader.c
+        sources/midifile.c
         sources/midistream.c)
 
 set_target_properties (midiface PROPERTIES VERSION ${PROJECT_VERSION})

--- a/headers/errutils.h
+++ b/headers/errutils.h
@@ -1,5 +1,5 @@
-#ifndef ERR_UTILS
-#define ERR_UTILS
+#ifndef MIDIFACE_ERRUTILS_H
+#define MIDIFACE_ERRUTILS_H
 
 #define FATAL 0b1000000000000000000000000000000
 #define MIDIFILE_OK 0x01
@@ -17,9 +17,7 @@
 #define FATAL_STRING_HEADER "FATAL ERROR"
 
 unsigned int midiface_pop_last_error();
-
 void midiface_throw_error(unsigned int code);
-
 extern unsigned int midifile_errors[MAX_ERRORS];
 extern int err_count;
 

--- a/headers/errutils.h
+++ b/headers/errutils.h
@@ -1,6 +1,8 @@
 #ifndef MIDIFACE_ERRUTILS_H
 #define MIDIFACE_ERRUTILS_H
 
+#include <headers/types.h>
+
 #define FATAL 0b1000000000000000000000000000000
 #define MIDIFILE_OK 0x01
 #define WRONG_MTHD  (0x02 + FATAL)
@@ -16,6 +18,9 @@
 #define ERROR_STRING_HEADER "ERROR"
 #define FATAL_STRING_HEADER "FATAL ERROR"
 
+void midiface_turn_off_quit_on_fatal();
+
+void midiface_turn_on_quit_on_fatal();
 unsigned int midiface_pop_last_error();
 void midiface_throw_error(unsigned int code);
 extern unsigned int midifile_errors[MAX_ERRORS];

--- a/headers/memutils.h
+++ b/headers/memutils.h
@@ -1,9 +1,14 @@
+#ifndef MIDIFACE_MEMUTILS_H
+#define MIDIFACE_MEMUTILS_H
+
 #include <stdio.h>
 
 // Copy memory as int
 unsigned int read_unsigned_integer(FILE *file_descriptor, size_t read_size);
-
 size_t secure_fread(char *buffer, size_t size, size_t n, FILE *file_descriptor);
 int secure_fseek(FILE *, size_t offset, int whence);
-
 size_t read_chunk(FILE *file_descriptor, char *bytes);
+
+size_t seek_remind(FILE *file_descriptor, int offset, int whence);
+
+#endif

--- a/headers/midifile.h
+++ b/headers/midifile.h
@@ -1,6 +1,9 @@
-#include "types.h"
-#include "errutils.h"
-#include "midiheader.h"
+#ifndef MIDIFACE_MIDIFILE_H
+#define MIDIFACE_MIDIFILE_H
+
+#include <headers/midiheader.h>
+#include <headers/types.h>
+#include <headers/errutils.h>
 
 #include <stdio.h>
 
@@ -9,8 +12,10 @@ typedef struct {
     FILE *file;
 } MIDIFile;
 
-MIDIFile *midiface_open_file(const char *filename);
-void midiface_dump_midifile_header(const MIDIFile *midifile);
-void midiface_close_midifile(MIDIFile *midifile);
+MIDIFile *midiface_create_file(FILE *);
 
+MIDIFile *midiface_open_file(const char *filename);
+void midiface_close_midifile(MIDIFile *midifile);
 bool midiface_validate_header(char *bytes);
+
+#endif

--- a/headers/midiheader.h
+++ b/headers/midiheader.h
@@ -1,7 +1,9 @@
 #ifndef MIDIFACE_MIDIHEADER_H
 #define MIDIFACE_MIDIHEADER_H
 
-#define MIDIHEADER_LENGTH 20
+#define MIDIHEADER_LENGTH 14
+
+#include <stdio.h>
 
 typedef struct {
     unsigned int format;
@@ -9,5 +11,7 @@ typedef struct {
     unsigned int ntracks;
     unsigned int division;
 } MIDIHeader;
+
+MIDIHeader *midiface_read_header(FILE *);
 
 #endif //MIDIFACE_MIDIHEADER_H

--- a/headers/types.h
+++ b/headers/types.h
@@ -1,2 +1,7 @@
+#ifndef MIDIFACE_TYPES_H
+#define MIDIFACE_TYPES_H
+
 typedef enum {false=0, true=1} bool;
 typedef unsigned char byte_t;
+
+#endif

--- a/sources/errutils.c
+++ b/sources/errutils.c
@@ -6,9 +6,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+bool errutils_global_quit_on_fatal = true;
 unsigned int midifile_errors[MAX_ERRORS] = {MIDIFILE_OK};
 int err_count=0;
 
+void midiface_turn_on_quit_on_fatal() {
+    errutils_global_quit_on_fatal = true;
+}
+
+void midiface_turn_off_quit_on_fatal() {
+    errutils_global_quit_on_fatal = false;
+}
 
 unsigned int midiface_pop_last_error() {
     const unsigned int error = midifile_errors[0];
@@ -52,7 +60,7 @@ void midiface_throw_error(const unsigned int code) {
     _add_error(code);
     char *error_string = _get_last_error_string(code);
     const static unsigned int fatal_code = FATAL;
-    if (code & fatal_code) {
+    if (errutils_global_quit_on_fatal && (code & fatal_code)) {
         send_log(ERROR, "[!] FATAL -> %s", error_string);
         free(error_string);
         exit(EXIT_FAILURE);

--- a/sources/memutils.c
+++ b/sources/memutils.c
@@ -44,3 +44,9 @@ int secure_fseek(FILE *file_descriptor, size_t offset, int whence) {
 size_t read_chunk(FILE *file_descriptor, char *bytes) {
     return secure_fread(bytes, 1, 4, file_descriptor);
 }
+
+size_t seek_remind(FILE *file_descriptor, int offset, int whence) {
+    size_t last_position = ftell(file_descriptor);
+    secure_fseek(file_descriptor, offset, whence);
+    return last_position;
+}

--- a/sources/midifile.c
+++ b/sources/midifile.c
@@ -15,11 +15,13 @@ MIDIFile *midiface_create_file(FILE *file_descriptor) {
 
 MIDIFile *midiface_open_file(const char *filename) {
     FILE *file_descriptor;
+    MIDIFile *midi_file = NULL;
     if (NULL == (file_descriptor = fopen(filename, "rb"))) {
         midiface_throw_error(FILE_OPENING);
+    } else {
+        midi_file = midiface_create_file(file_descriptor);
+        send_log(DEBUG, "MIDIFile@%p created with file@%p", midi_file, midi_file->file);
     }
-    MIDIFile *midi_file = midiface_create_file(file_descriptor);
-    send_log(DEBUG, "MIDIFile@%p created with file@%p", midi_file, midi_file->file);
     return midi_file;
 }
 

--- a/sources/midifile.c
+++ b/sources/midifile.c
@@ -6,39 +6,26 @@
 #include <stdlib.h>
 #include <string.h>
 
+MIDIFile *midiface_create_file(FILE *file_descriptor) {
+    MIDIFile *midi_file = malloc(sizeof(MIDIFile));
+    midi_file->file = file_descriptor;
+    midi_file->header = midiface_read_header(file_descriptor);
+    return midi_file;
+}
+
 MIDIFile *midiface_open_file(const char *filename) {
     FILE *file_descriptor;
-    char mthd[4];
-    MIDIFile *midifile = malloc(sizeof(MIDIFile));
-    midifile->header = malloc(sizeof(MIDIHeader));
     if (NULL == (file_descriptor = fopen(filename, "rb"))) {
         midiface_throw_error(FILE_OPENING);
     }
-    read_chunk(file_descriptor, mthd);
-    if (!(midiface_validate_header(mthd))) {
-        midiface_throw_error(WRONG_MTHD);
-    }
-    midifile->file = file_descriptor;
-    midifile->header->length = read_unsigned_integer(file_descriptor, 4);
-    midifile->header->format = read_unsigned_integer(file_descriptor, 2);
-    midifile->header->ntracks = read_unsigned_integer(file_descriptor, 2);
-    midifile->header->division = read_unsigned_integer(file_descriptor, 2);
-    send_log(DEBUG, "MIDIFile@%p created with file@%p", midifile, midifile->file);
-    return midifile;
-}
-
-bool midiface_validate_header(char *bytes) {
-    static const unsigned char mthd[] = {0x4d, 0x54, 0x68, 0x64};
-    return memcmp(bytes, mthd, sizeof mthd) == 0;
+    MIDIFile *midi_file = midiface_create_file(file_descriptor);
+    send_log(DEBUG, "MIDIFile@%p created with file@%p", midi_file, midi_file->file);
+    return midi_file;
 }
 
 void midiface_close_midifile(MIDIFile *midifile) {
-    /*
-    if(midifile->tracks != NULL) {
-       free(midifile->tracks);
-    }
-    */
     send_log(DEBUG, "freeing MIDIFile@%p with file@%p", midifile, midifile->file);
     fclose(midifile->file);
+    free(midifile->header);
     free(midifile);
 }

--- a/sources/midiheader.c
+++ b/sources/midiheader.c
@@ -1,0 +1,28 @@
+#include <headers/errutils.h>
+#include <headers/memutils.h>
+#include <headers/midiheader.h>
+#include <headers/types.h>
+
+#include <malloc.h>
+#include <string.h>
+
+bool _validate_mthd(char *bytes) {
+    static const unsigned char mthd[] = {0x4d, 0x54, 0x68, 0x64};
+    return memcmp(bytes, mthd, sizeof mthd) == 0;
+}
+
+MIDIHeader *midiface_read_header(FILE *file_descriptor) {
+    secure_fseek(file_descriptor, 0, SEEK_SET);
+    char mthd[4];
+    read_chunk(file_descriptor, mthd);
+    if (!_validate_mthd(mthd)) {
+        midiface_throw_error(WRONG_MTHD);
+    }
+    MIDIHeader *header = malloc(sizeof(MIDIHeader));
+    header->length = read_unsigned_integer(file_descriptor, 4);
+    header->format = read_unsigned_integer(file_descriptor, 2);
+    header->ntracks = read_unsigned_integer(file_descriptor, 2);
+    header->division = read_unsigned_integer(file_descriptor, 2);
+    return header;
+}
+

--- a/sources/midistream.c
+++ b/sources/midistream.c
@@ -41,10 +41,8 @@ int midiface_get_stream_length(MIDIStream *stream) {
     size_t source_size = -1;
     if (stream->type == IMMUTABLE) {
         MIDIFile *midifile = (MIDIFile *) midiface_get_stream_source(stream);
-        const size_t initial_position = ftell(midifile->file);
-        secure_fseek(midifile->file, 0, SEEK_END);
-        source_size = ftell(midifile->file);
-        secure_fseek(midifile->file, initial_position, SEEK_SET);
+        const size_t initial_position = seek_remind(midifile->file, 0, SEEK_END);
+        source_size = seek_remind(midifile->file, initial_position, SEEK_SET);
     } else if (stream->type == CONTINUOUS || stream->type == LISTENING) {
         // CONTINUOUS and LISTENING have infinite length because it sends at any time any data
         // A size should be calculated after it has been closed.

--- a/tests/sources/fixtures.c
+++ b/tests/sources/fixtures.c
@@ -1,0 +1,24 @@
+#ifndef MIDIFACE_TEST_FIXTURES_H
+#define MIDIFACE_TEST_FIXTURES_H
+
+char header_only_data[MIDIHEADER_LENGTH] = {'M', 'T', 'h', 'd', // 1: MIDI file header
+                                            0x00, 0x00, 0x00, 0x06, // 4: Length = 6
+                                            0x00, 0x01, // 6: Multi-track file
+                                            0x00, 0x02, // 8: 2 tracks
+                                            0x00, 96};  // 10: division 96
+
+char two_tracks_data[46] = {'M', 'T', 'h', 'd', // 1: MIDI file header
+                            0x00, 0x00, 0x00, 0x06, // 4: Length = 6
+                            0x00, 0x01, // 8: Multi-track file
+                            0x00, 0x02, // 12: 2 tracks
+                            0x00, 96, // 16: 96 time per quarter note
+                            'M', 'T', 'r', 'k', // 20: First track
+                            0x00, 0x00, 0x00, 0x08, // 24: 8 bytes long
+                            0x00, 0x00, 0x00, 0x00, // 28: Delta-time to 0
+                            0x00, 0x00, 0x00, 0x00, // 32: Playing C0
+                            'M', 'T', 'r', 'k', // 36: Second track
+                            0x00, 0x00, 0x00, 0x08, // 40: 8 bytes long
+                            0x00, 0x00, 0x00, 0x00, // 44: Delta-time to 0
+                            0x00, 0x00, 0x00, 0x00}; // 48: Playing C0
+
+#endif //MIDIFACE_TEST_FIXTURES_H

--- a/tests/sources/test_api.c
+++ b/tests/sources/test_api.c
@@ -1,0 +1,28 @@
+#ifndef MIDIFACE_TEST_API_GUARD
+#define MIDIFACE_TEST_API_GUARD
+
+#include <headers/midifile.h>
+#include <headers/midistream.h>
+
+#include <malloc.h>
+
+MIDIStream *create_in_memory_midistream(const enum Stream_Type type, char *raw_data, const size_t buffer_size) {
+    if (type == IMMUTABLE) {
+        MIDIStream *stream = midiface_create_stream(IMMUTABLE);
+        FILE *file = fmemopen(raw_data, buffer_size, "rb");
+        MIDIFile *midi_file = midiface_create_file(file);
+        stream->source = midi_file;
+        midi_file->header = midiface_read_header(midi_file->file);
+        return stream;
+    } else if (type == CONTINUOUS) {
+        midiface_throw_error(NOT_IMPLEMENTED);
+    } else if (type == LISTENING) {
+        midiface_throw_error(NOT_IMPLEMENTED);
+    } else {
+        fprintf(stderr, "No stream type declared");
+        midiface_throw_error(FATAL);
+    }
+}
+
+#endif
+

--- a/tests/sources/test_midifile.c
+++ b/tests/sources/test_midifile.c
@@ -1,15 +1,43 @@
 #include <headers/midifile.h>
+#include <headers/errutils.h>
 
-void midi_file_valid_header_test() {
-    const MIDIFile *valid_MIDIFile = midiface_open_file("tests/files/SuperMario64.mid");
+#include "fixtures.c"
+
+void test_midi_file_valid_header() {
+    FILE *file_descriptor = fmemopen(header_only_data, MIDIHEADER_LENGTH, "rb");
+
+    const MIDIFile *valid_MIDIFile = midiface_create_file(file_descriptor);
+
     CU_ASSERT_EQUAL(valid_MIDIFile->header->length, 6);
     CU_ASSERT_EQUAL(valid_MIDIFile->header->format, 1);
-    CU_ASSERT_EQUAL(valid_MIDIFile->header->ntracks, 3);
-    CU_ASSERT_EQUAL(valid_MIDIFile->header->division, 1024);
+    CU_ASSERT_EQUAL(valid_MIDIFile->header->ntracks, 2);
+    CU_ASSERT_EQUAL(valid_MIDIFile->header->division, 96);
+}
+
+void test_midifile_open() {
+    MIDIFile *midi_file = NULL;
+
+    midi_file = midiface_open_file("tests/files/SuperMario64.mid");
+
+    CU_ASSERT_PTR_NOT_NULL(midi_file->file);
+}
+
+void test_open_unexisting() {
+    MIDIFile *midi_file = NULL;
+
+    midi_file = midiface_open_file("tests/files/unexisting.mid");
+
+    const unsigned int error_code = midiface_pop_last_error();
+    CU_ASSERT_EQUAL(error_code, FILE_OPENING);
+    CU_ASSERT_PTR_NULL(midi_file->file);
 }
 
 void init_midifile_suite() {
     CU_pSuite file_test_suite = CU_add_suite("Test file reading", NULL, NULL);
     CU_add_test(file_test_suite, "Test that a valid file header is read correctly",
-                midi_file_valid_header_test);
+                test_midi_file_valid_header);
+    CU_add_test(file_test_suite, "Test that a valid file can be opened",
+                test_midifile_open);
+    CU_add_test(file_test_suite, "Test that opening a non existing file throws error",
+                test_midifile_open);
 }

--- a/tests/sources/test_midifile.c
+++ b/tests/sources/test_midifile.c
@@ -22,14 +22,14 @@ void test_midifile_open() {
     CU_ASSERT_PTR_NOT_NULL(midi_file->file);
 }
 
-void test_open_unexisting() {
+void test_midifile_open_unexisting() {
     MIDIFile *midi_file = NULL;
 
     midi_file = midiface_open_file("tests/files/unexisting.mid");
 
     const unsigned int error_code = midiface_pop_last_error();
     CU_ASSERT_EQUAL(error_code, FILE_OPENING);
-    CU_ASSERT_PTR_NULL(midi_file->file);
+    CU_ASSERT_PTR_NULL(midi_file);
 }
 
 void init_midifile_suite() {
@@ -39,5 +39,5 @@ void init_midifile_suite() {
     CU_add_test(file_test_suite, "Test that a valid file can be opened",
                 test_midifile_open);
     CU_add_test(file_test_suite, "Test that opening a non existing file throws error",
-                test_midifile_open);
+                test_midifile_open_unexisting);
 }

--- a/tests/sources/test_midistream.c
+++ b/tests/sources/test_midistream.c
@@ -4,83 +4,60 @@
 #include <stdio.h>
 #include <malloc.h>
 
+#include "fixtures.c"
+#include "test_api.c"
 
-char two_tracks_midifile_data[52] = {'M', 'T', 'h', 'd', // 1: MIDI track header
-                                     0x00, 0x00, 0x00, 0x06, // 4: Length = 6
-                                     0x00, 0x00, 0x00, 0x01, // 8: Multi-track file
-                                     0x00, 0x00, 0x00, 0x02, // 12: 2 tracks
-                                     0x00, 0x00, 0x00, 96, // 16: 96 time per quarter note
-                                     'M', 'T', 'r', 'k', // 20: First track
-                                     0x00, 0x00, 0x00, 0x08, // 24: 8 bytes long
-                                     0x00, 0x00, 0x00, 0x00, // 28: Delta-time to 0
-                                     0x00, 0x00, 0x00, 0x00, // 32: Playing C0
-                                     'M', 'T', 'r', 'k', // 36: Second track
-                                     0x00, 0x00, 0x00, 0x08, // 40: 8 bytes long
-                                     0x00, 0x00, 0x00, 0x00, // 44: Delta-time to 0
-                                     0x00, 0x00, 0x00, 0x00 // 48: Playing C0
-};
+void test_immutable_stream_header_ok() {
+    MIDIStream *stream = create_in_memory_midistream(IMMUTABLE, header_only_data, MIDIHEADER_LENGTH);
 
-/**
- * The immutable stream does not send data continuously, it is often a file read once and closed.
- * This stream has a length because it is ending.
- */
-void test_immutable_stream() {
-    MIDIStream *stream = midiface_create_stream(IMMUTABLE);
-    midiface_open_stream_source(stream, "tests/files/SuperMario64.mid");
     MIDIHeader *header = midiface_get_stream_header(stream);
     const int stream_length = midiface_get_stream_length(stream);
-    CU_ASSERT_EQUAL(48700, stream_length);
+
+    CU_ASSERT_EQUAL(MIDIHEADER_LENGTH, stream_length);
     CU_ASSERT_EQUAL(header->length, 6);
     CU_ASSERT_EQUAL(header->format, 1);
-    CU_ASSERT_EQUAL(header->ntracks, 3);
-    CU_ASSERT_EQUAL(header->division, 1024);
+    CU_ASSERT_EQUAL(header->ntracks, 2);
+    CU_ASSERT_EQUAL(header->division, 96);
     midiface_close_stream(stream);
 }
 
 void test_midistream_file_get_source() {
-    MIDIStream *midistream = midiface_create_stream(IMMUTABLE);
-    midiface_open_stream_source(midistream, "tests/files/SuperMario64.mid");
+    MIDIStream *midistream = create_in_memory_midistream(IMMUTABLE, header_only_data, MIDIHEADER_LENGTH);
+
     MIDIFile *midifile = midiface_get_stream_source(midistream);
+
     CU_ASSERT_EQUAL(midifile->header->length, 6);
     CU_ASSERT_EQUAL(midifile->header->format, 1);
-    CU_ASSERT_EQUAL(midifile->header->ntracks, 3);
-    CU_ASSERT_EQUAL(midifile->header->division, 1024);
+    CU_ASSERT_EQUAL(midifile->header->ntracks, 2);
+    CU_ASSERT_EQUAL(midifile->header->division, 96);
     midiface_close_stream(midistream);
 }
 
 void test_midistream_get_stream_tracks_count() {
-    MIDIFile midifile;
-    MIDIStream midistream;
-    midifile.file = fmemopen(two_tracks_midifile_data, 52, "rb");
-    midistream.type = IMMUTABLE;
-    midistream.source = &midifile;
+    MIDIStream *stream = create_in_memory_midistream(IMMUTABLE, two_tracks_data, 46);
 
-    const unsigned int real_tracks_count = midiface_get_stream_tracks_count(&midistream);
+    const unsigned int real_tracks_count = midiface_get_stream_tracks_count(stream);
 
     CU_ASSERT_EQUAL(real_tracks_count, 2);
-    fclose(midifile.file);
+    midiface_close_stream(stream);
 }
 
 void test_midistream_file_get_tracks() {
-    MIDIFile midifile;
-    MIDIStream midistream;
-    midifile.file = fmemopen(two_tracks_midifile_data, 52, "r");
-    midistream.type = IMMUTABLE;
-    midistream.source = &midifile;
-    midifile.header = midiface_get_stream_source(&midistream);
+    MIDIStream *stream = create_in_memory_midistream(IMMUTABLE, two_tracks_data, 46);
 
-    MIDITrack **tracks = midiface_get_stream_tracks(&midistream);
+    MIDITrack **tracks = midiface_get_stream_tracks(stream);
 
     CU_ASSERT_EQUAL(tracks[0]->length, 8);
     CU_ASSERT_EQUAL(tracks[1]->length, 8);
     free(tracks[0]);
     free(tracks[1]);
+    midiface_close_stream(stream);
 }
 
 void init_midistream_suite() {
     CU_pSuite stream_test_suite = CU_add_suite("Test stream reading/writing", NULL, NULL);
-    CU_add_test(stream_test_suite, "Test that an immutable stream from a file on the system is correct",
-                test_immutable_stream);
+    CU_add_test(stream_test_suite, "Test that an immutable stream header is OK",
+                test_immutable_stream_header_ok);
     CU_add_test(stream_test_suite, "Test that an immutable stream from a file gets its source correctly",
                 test_midistream_file_get_source);
     CU_add_test(stream_test_suite, "Test that real tracks count from an immutable stream is correct",

--- a/tests/sources/tests.c
+++ b/tests/sources/tests.c
@@ -4,6 +4,8 @@
 #include "test_memutils.c"
 #include "test_logger.c"
 
+#include <headers/errutils.h>
+
 void init_test_suites() {
     init_memutils_suite();
     init_midifile_suite();
@@ -18,6 +20,7 @@ int main(int argc, char **argv) {
     }
     init_test_suites();
     CU_basic_set_mode(CU_BRM_VERBOSE);
+    midiface_turn_off_quit_on_fatal();
     if (argc > 1) {
         const char* suite_name = argv[1];
         CU_pSuite test_suite = CU_get_suite(suite_name);

--- a/tests/sources/tests.c
+++ b/tests/sources/tests.c
@@ -28,8 +28,10 @@ int main(int argc, char **argv) {
             for(int i=2; i < argc; i++) {
                 char* test_name = argv[i];
                 CU_pTest test_to_run = CU_get_test(test_suite, test_name);
-                CU_basic_run_test(test_suite, test_to_run);
+                CU_add_test(chosen_tests_suite, test_to_run->pName,
+                            test_to_run->pTestFunc);
             }
+            CU_basic_run_suite(chosen_tests_suite);
         }
     } else {
         CU_basic_run_tests();


### PR DESCRIPTION
- new test helper that create an in memoty file
- adding header guards and updating wrong names
- Function to read MIDI header
- seek_remind helper to keep track of the last file cursor position when moving it to another position
- Updating each midistream test to use an in memory file
- Helper to create MIDIFile
- Adding fixtures
- Running multiples tests in one suite